### PR TITLE
Redirects to new TVMCon website

### DIFF
--- a/_includes/themes/custom-twitter/default.html
+++ b/_includes/themes/custom-twitter/default.html
@@ -35,6 +35,12 @@
     <meta property="twitter:title" content="TVMCon 2021">
     <meta property="twitter:description" content="The Open Source Machine Learning Acceleration Conference">
     <meta property="twitter:image" content="https://tvmconf.org/assets/themes/custom-twitter/css/tvmcon.png">
+
+    <meta http-equiv="refresh" content="0; url=https://www.tvmcon.org">
+
+    <script>
+      window.location.href = "https://www.tvmcon.org"
+    </script>
 </head>
 
   <body>


### PR DESCRIPTION
Redirects to the new TVMCon website, https://www.tvmcon.org